### PR TITLE
Disallow multiple connect() on same Connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - cd $TRAVIS_BUILD_DIR
   - mkdir build
   - cd build
-  - LDFLAGS="-undefined dynamic_lookup" cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%USERPROFILE%  -DCYANODBC_TARGET_PYTHON=3.5 ..
+  - LDFLAGS="-undefined dynamic_lookup" cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME  -DCYANODBC_TARGET_PYTHON=3.5 ..
   - cmake --build .
   - pip install src/python/dist/Cyanodbc-0.0.1-py3-none-any.whl
   - cp $TRAVIS_BUILD_DIR/ci/.odbcinst.ini ~/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,11 +5,15 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "test",
+            "label": "osx build",
             "type": "shell",
             "command": [
-                "call activate py36 &&",
-                "pytest"
+                "source activate py35 \n",
+                "rm -rf \"${workspaceFolder}/build\" \n",
+                "mkdir \"${workspaceFolder}/build\" \n",
+                "cd \"${workspaceFolder}/build\" \n",
+                "LDFLAGS=\"-undefined dynamic_lookup\" cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$HOME  -DCYANODBC_TARGET_PYTHON=3.5 \"${workspaceFolder}\" \n",
+                "cmake --build \"${workspaceFolder}/build\" \n"
             ]
         },
         {

--- a/src/cython/cyanodbc/connection.pxi
+++ b/src/cython/cyanodbc/connection.pxi
@@ -5,7 +5,7 @@ cdef class Connection:
     def __cinit__(self):
         self.c_cnxn = nanodbc.connection()
 
-    def connect(self, dsn, username=None, password=None, long timeout=0):
+    def _connect(self, dsn, username=None, password=None, long timeout=0):
         if username and password:
             self.c_cnxn.connect(dsn.encode(),username.encode(), password.encode(), timeout)
         else:
@@ -45,3 +45,8 @@ cdef class Connection:
     # @property
     # def catalog_name(self):
     #     return self.c_cnxn.catalog_name().decode('UTF-8')
+
+def connect(dsn, username=None, password=None, long timeout=0):
+    cnxn = Connection()
+    cnxn._connect(dsn, username, password, timeout)
+    return cnxn

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(name='Cyanodbc',
+      version='0.0.1',
+      package_dir={ '': '.' },
+      package_data={'cyanodbc':['*.*']},
+      packages=['cyanodbc'])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -42,17 +42,11 @@ def sqlite_db():
 
 @pytest.fixture(scope="module")
 def connection(sqlite_db):
-    cnxn = cyanodbc.Connection()
-    cnxn.connect("DRIVER=SQLite3 ODBC Driver;Database="
+    cnxn = cyanodbc.connect("DRIVER=SQLite3 ODBC Driver;Database="
     "example.db;LongNames=0;Timeout=1000;NoTXN=0;SyncPragma=NORMAL;StepAPI=0;")
     yield cnxn
 
-def test_connection_create():
-    cnxn = cyanodbc.Connection()
-    assert not cnxn.connected
-
 def test_connection_properties(connection):
-    
     assert connection.connected
     assert connection.get_info(SQLGetInfo.SQL_DBMS_NAME) == "SQLite"
     assert connection.get_info(SQLGetInfo.SQL_DATABASE_NAME) == "example.db"
@@ -76,11 +70,12 @@ def test_cursor_wlongvarchar_to_py(connection, sqlite_db):
     for row in rows:
         assert row in [('💮', ), ('RHAT', ), ('IBM',), ('DELL',)]
 
-@pytest.mark.skip(reason="Missing functionality")
-def test_multiple_open_connection(connection, sqlite_db):
-    connection.connect("DRIVER=SQLite3 ODBC Driver;Database="
+def test_multiple_open_connection():
+    connection = cyanodbc.connect("DRIVER=SQLite3 ODBC Driver;Database="
     "example.db;LongNames=0;Timeout=1000;NoTXN=0;SyncPragma=NORMAL;StepAPI=0;")
     cursor = connection.cursor()
     cursor.execute("select 'a'")
-    connection.connect("DRIVER=SQLite3 ODBC Driver;Database="
+    connection = cyanodbc.connect("DRIVER=SQLite3 ODBC Driver;Database="
     "example.db;LongNames=0;Timeout=1000;NoTXN=0;SyncPragma=NORMAL;StepAPI=0;")
+    cursor = connection.cursor()
+    cursor.execute("select 'a'")


### PR DESCRIPTION
- Fix #6
- Make connect a private function
- Connection may only be instantiated using cyanodbc.connect()
- Change tests to use this new interface
- Add VSCode helper tasks for OSX
- Fix typo in travis build step